### PR TITLE
Updated security groups to be more restrictive.

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -55,10 +55,10 @@ output "cluster_name" {
 
 output "security_group_id" {
   description = "The ID of the security group rule"
-  value       = join("", aws_security_group.default.*.id)
+  value       = join("", module.security_group.*.id)
 }
 
 output "security_group_name" {
   description = "The name of the security group rule"
-  value       = join("", aws_security_group.default.*.name)
+  value       = join("", module.security_group.*.name)
 }

--- a/variables.tf
+++ b/variables.tf
@@ -41,10 +41,16 @@ variable "security_groups" {
   description = "List of security group IDs to be allowed to connect to the cluster"
 }
 
-variable "allowed_cidr_blocks" {
+variable "allowed_ingress_cidr_blocks" {
   type        = list(string)
   default     = []
-  description = "List of CIDR blocks to be allowed to connect to the cluster"
+  description = "List of ingress CIDR blocks to be allowed to connect to the cluster"
+}
+
+variable "allowed_egress_cidr_blocks" {
+  type        = list(string)
+  default     = []
+  description = "List of egress CIDR blocks to be allowed to connect to the cluster"
 }
 
 variable "client_broker" {


### PR DESCRIPTION
## what
- I replaced security group resources with the AWS SG module, limiting ports exposed to only those needed by Kafka for both egress and ingress. 
- I also allow for ingress and egress CIDRs to be defined separately.

## why
- Security groups are currently set to expose ALL ports. 
- Best practice is to only allow what is necessary. 
- AWS Security Groups module has a Kafka definition that solves this problem.
- Egress and Ingress CIDR blocks may differ and therefore need to be separate variables.

## references
* https://github.com/terraform-aws-modules/terraform-aws-security-group/tree/master/modules/kafka

